### PR TITLE
Ignore errors on `npm list` when using with yarn

### DIFF
--- a/src/detect/read-dependency-tree.coffee
+++ b/src/detect/read-dependency-tree.coffee
@@ -1,14 +1,31 @@
+fs = require 'fs'
 Promise = require 'bluebird'
-childProcess = require('child_process')
+childProcess = require 'child_process'
 
 execFile = Promise.promisify childProcess.execFile, multiArgs: true
+
+# This function is intended to be used with yarn until a better option is available.
+# Its dangerous to use because its ignoring any errors.
+execFileDangerously = (command, args, options) ->
+    return new Promise (resolve, reject) ->
+        childProcess.execFile command, args, options, (error, stdout, stderr) ->
+            resolve [stdout, stderr]
+
+isYarnInUse = ->
+    return fs.existsSync "#{process.cwd()}/yarn.lock"
 
 module.exports = Promise.coroutine (dev = false, modulePath) ->
     options =
         maxBuffer: 26 * 1024 * 1024
     options.cwd = modulePath if modulePath?
 
-    [stdout] = yield execFile 'npm', [
+    if isYarnInUse()
+        console.log 'yarn.lock found. Suppressing errors coming from npm ls.'
+        _execFile = execFileDangerously
+    else
+        _execFile = execFile
+
+    [stdout] = yield _execFile 'npm', [
         'list'
         '--json'
         '--long'

--- a/src/detect/read-dependency-tree.coffee
+++ b/src/detect/read-dependency-tree.coffee
@@ -11,15 +11,16 @@ execFileDangerously = (command, args, options) ->
         childProcess.execFile command, args, options, (error, stdout, stderr) ->
             resolve [stdout, stderr]
 
-isYarnInUse = ->
-    return fs.existsSync "#{process.cwd()}/yarn.lock"
+isYarnInUse = (cwd) ->
+    cwd = process.cwd() unless cwd?
+    return fs.existsSync "#{cwd}/yarn.lock"
 
 module.exports = Promise.coroutine (dev = false, modulePath) ->
     options =
         maxBuffer: 26 * 1024 * 1024
     options.cwd = modulePath if modulePath?
 
-    if isYarnInUse()
+    if isYarnInUse modulePath
         console.log 'yarn.lock found. Suppressing errors coming from npm ls.'
         _execFile = execFileDangerously
     else

--- a/test/advocate-integration.coffee
+++ b/test/advocate-integration.coffee
@@ -8,6 +8,7 @@ map = require 'lodash/fp/map'
 
 advocate = require '../src/index'
 testDataPathA = path.join __dirname, 'integration-data/a'
+testDataPathB = path.join __dirname, 'integration-data/b'
 
 describe 'advocate integration test', ->
 
@@ -98,3 +99,15 @@ describe 'advocate integration test', ->
 
             it 'doesn\'t contains non-violating modules', ->
                 expect(map 'explicitName', violatingModules).to.not.contain 'b@0.0.1'
+
+    describe 'yarn.lock present', ->
+
+        it 'should not throw error from npm list', Promise.coroutine ->
+            whitelist =
+                licenses: ['MIT', 'JSON']
+
+            options =
+                dev: false
+                path: testDataPathB
+
+            {allModules} = yield advocate whitelist, options

--- a/test/advocate-integration.coffee
+++ b/test/advocate-integration.coffee
@@ -7,7 +7,7 @@ path = require 'path'
 map = require 'lodash/fp/map'
 
 advocate = require '../src/index'
-testDataPath = path.join __dirname, 'integration-data/a'
+testDataPathA = path.join __dirname, 'integration-data/a'
 
 describe 'advocate integration test', ->
 
@@ -15,7 +15,7 @@ describe 'advocate integration test', ->
 
         context 'with no given parameters', ->
             it 'returns without error', Promise.coroutine ->
-                options = {path: testDataPath}
+                options = {path: testDataPathA}
                 {allModules, violatingModules} = yield advocate()
 
                 expect(violatingModules).to.be.an 'object'
@@ -23,8 +23,8 @@ describe 'advocate integration test', ->
 
         context 'with no given whitelist', ->
             it 'returns all production dependencies for given path', Promise.coroutine ->
-                options = {path: testDataPath}
-                {allModules, violatingModules} = yield advocate null, {path: testDataPath}
+                options = {path: testDataPathA}
+                {allModules, violatingModules} = yield advocate null, {path: testDataPathA}
 
                 expect(map 'explicitName', violatingModules).to.have.members [
                     'b@0.0.1'
@@ -33,7 +33,7 @@ describe 'advocate integration test', ->
 
         context 'with no given license whitelist', ->
             it 'returns all violating dependencies for given path', Promise.coroutine ->
-                options = {path: testDataPath}
+                options = {path: testDataPathA}
                 whitelist =
                     modules: [
                         name: 'c'
@@ -41,7 +41,7 @@ describe 'advocate integration test', ->
                         licenseDescriptor: 'Apache-2.0 WITH LZMA-exception'
                     ]
 
-                {allModules, violatingModules} = yield advocate whitelist, {path: testDataPath}
+                {allModules, violatingModules} = yield advocate whitelist, {path: testDataPathA}
 
                 expect(map 'explicitName', violatingModules).to.have.members [
                     'b@0.0.1'
@@ -63,7 +63,7 @@ describe 'advocate integration test', ->
 
             options =
                 dev: false
-                path: testDataPath
+                path: testDataPathA
 
             {allModules, violatingModules} = yield advocate whitelist, options
 

--- a/test/integration-data/b/node_modules/b/package.json
+++ b/test/integration-data/b/node_modules/b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "b",
+  "version": "0.0.1",
+  "license": "JSON AND MIT"
+}

--- a/test/integration-data/b/node_modules/e/package.json
+++ b/test/integration-data/b/node_modules/e/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "e",
+  "version": "0.0.1",
+  "license": "BSD OR Apache-2.0"
+}

--- a/test/integration-data/b/package.json
+++ b/test/integration-data/b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "a",
+  "version": "0.0.1",
+  "license": "MIT",
+  "dependencies": {
+    "b": "^0.0.1",
+    "not-existent": "^0.0.1"
+  }
+}


### PR DESCRIPTION
This add yarn compatibility by using an ugly hack.

We still call `npm ls` but suppress errors.